### PR TITLE
Support for writing out supply/demand curves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 .Rproj.user
+cvs/objects/.vscode
+output-

--- a/cvs/objects/containers/source/scenario.cpp
+++ b/cvs/objects/containers/source/scenario.cpp
@@ -66,6 +66,7 @@
 #include "solution/util/include/solution_info_param_parser.h" 
 #include "containers/include/imodel_feedback_calc.h"
 #include "util/base/include/manage_state_variables.hpp"
+#include "util/base/include/supply_demand_curve_saver.h"
 
 #if GCAM_PARALLEL_ENABLED && PARALLEL_DEBUG
 #include <stdlib.h>
@@ -173,6 +174,9 @@ bool Scenario::XMLParse( const DOMNode* node ){
         }
         else if( nodeName == SolutionInfoParamParser::getXMLNameStatic() ) {
             parseSingleNode( curr, mSolutionInfoParamParser, new SolutionInfoParamParser );
+        }
+        else if ( nodeName == SupplyDemandCurveSaver::getXMLNameStatic()) {
+            parseContainerNode( curr, mModelFeedbacks, new SupplyDemandCurveSaver );
         }
         
         /*!
@@ -498,9 +502,6 @@ bool Scenario::calculatePeriod( const int aPeriod,
     
     
     bool success = solve( aPeriod ); // solution uses Bisect and NR routine to clear markets
-    
-    delete mManageStateVars;
-    mManageStateVars = 0;
 
     mWorld->postCalc( aPeriod );
     
@@ -538,6 +539,9 @@ bool Scenario::calculatePeriod( const int aPeriod,
         writeDebuggingFiles( aXMLDebugFile, aSGMDebugFile, aTabs, aPeriod );
     }
 
+    delete mManageStateVars;
+    mManageStateVars = 0;
+    
     return success;
 }
 

--- a/cvs/objects/solution/util/include/solution_info_set.h
+++ b/cvs/objects/solution/util/include/solution_info_set.h
@@ -112,7 +112,7 @@ public:
     bool hasSingularUnsolved();
     void unsetBisectedFlag();
     void printUnsolved( std::ostream& out );
-    void findAndPrintSD( World* aWorld, Marketplace* aMarketplace, const int aPeriod, ILogger& aLogger );
+    void findAndPrintSD( World* aWorld, Marketplace* aMarketplace, const int aPeriod, std::ostream& aOut );
     void printMarketInfo( const std::string& comment, const double worldCalcCount, std::ostream& out ) const;
     void printDerivatives( std::ostream& aOut ) const;
 

--- a/cvs/objects/solution/util/source/solution_info_set.cpp
+++ b/cvs/objects/solution/util/source/solution_info_set.cpp
@@ -626,11 +626,11 @@ void SolutionInfoSet::printMarketInfo( const string& aLocation,
 * \param aPeriod Period for which to print supply-demand curves.
 * \param aLogger Logger stream to print the curves to.
 */
-void SolutionInfoSet::findAndPrintSD( World* aWorld, Marketplace* aMarketplace, const int aPeriod, ILogger& aLogger ) {
+void SolutionInfoSet::findAndPrintSD( World* aWorld, Marketplace* aMarketplace, const int aPeriod, ostream& aOut) {
     const Configuration* conf = Configuration::getInstance();
     const int numMarketsToFindSD = conf->getInt( "numMarketsToFindSD", 5 );
     const int numPointsForSD = conf->getInt( "numPointsForSD", 5 );
-    
+   
     // Sort the vector so the worst markets are first.
     sort( solvable.begin(), solvable.end(), SolutionInfo::GreaterRelativeED() );
 
@@ -642,7 +642,7 @@ void SolutionInfoSet::findAndPrintSD( World* aWorld, Marketplace* aMarketplace, 
         }
         SupplyDemandCurve sdCurve( i, solvable[ i ].getName() );
         sdCurve.calculatePoints( numPointsForSD, *this, aWorld, aMarketplace, aPeriod );
-        sdCurve.print( aLogger );
+        sdCurve.print( aOut );
     }
 }
 

--- a/cvs/objects/util/base/include/auto_file.h
+++ b/cvs/objects/util/base/include/auto_file.h
@@ -93,13 +93,14 @@ public:
     /*! \brief Open an output file with the given name.
     * \details Opens an automatically closing output file with a given filename.
     * \param aFileName Name of the file to open.
+     * \param aOpenMode The file opening mode. Use std::ios_base::app to open in append mode.
     * \todo This interface is dangerous because forgetting an argument calls a
     *       different function.
     */
-    explicit AutoOutputFile( const std::string& aFileName )
+    explicit AutoOutputFile( const std::string& aFileName, std::ios_base::openmode aOpenMode = std::ios_base::out )
         :mShouldWrite( true )
     {
-        boost::iostreams::file_sink fileBuffer( aFileName );
+        boost::iostreams::file_sink fileBuffer( aFileName, aOpenMode );
         mWrappedFile.push( fileBuffer );
         util::checkIsOpen( fileBuffer, aFileName );
     }

--- a/cvs/objects/util/base/include/supply_demand_curve.h
+++ b/cvs/objects/util/base/include/supply_demand_curve.h
@@ -68,7 +68,7 @@ public:
     void calculatePoints( const int aNumPoints, SolutionInfoSet& aSolnSet, World* aWorld,
                           Marketplace* aMarketplace, const int aPeriod );
     void print( std::ostream& aOut ) const;
-    void print2( std::ostream& aOut, int period, bool printHeader ) const;
+    void printCSV( std::ostream& aOut, int period, bool aPrintHeader ) const;
     
 private:
     //! Index to the market which the curve is calculating for.

--- a/cvs/objects/util/base/include/supply_demand_curve.h
+++ b/cvs/objects/util/base/include/supply_demand_curve.h
@@ -67,8 +67,9 @@ public:
     ~SupplyDemandCurve();
     void calculatePoints( const int aNumPoints, SolutionInfoSet& aSolnSet, World* aWorld,
                           Marketplace* aMarketplace, const int aPeriod );
-   void print( ILogger& aSDLog ) const;
-
+    void print( std::ostream& aOut ) const;
+    void print2( std::ostream& aOut, int period, bool printHeader ) const;
+    
 private:
     //! Index to the market which the curve is calculating for.
     int mMarketNumber;
@@ -88,7 +89,7 @@ class SupplyDemandPoint
 public:
    SupplyDemandPoint( const double aPrice, const double aDemand, const double aSupply, const double aFx );
    double getPrice() const;
-   void print( ILogger& aSDLog ) const;
+   void print( std::ostream& aOut ) const;
    
 /*!
 * \brief Binary comparison operator used for SavePoint pointers to order by increasing price. 

--- a/cvs/objects/util/base/include/supply_demand_curve.h
+++ b/cvs/objects/util/base/include/supply_demand_curve.h
@@ -65,8 +65,14 @@ class SupplyDemandCurve {
 public:
     SupplyDemandCurve( int aMarketNumber, const std::string& aMarketName );
     ~SupplyDemandCurve();
+
+    void calculatePoints( const std::vector<double>& aPrices, SolutionInfoSet& aSolnSet, World* aWorld,
+                          Marketplace* aMarketplace, const int aPeriod, bool aIsPricesRelative );
+
+    // Legacy version
     void calculatePoints( const int aNumPoints, SolutionInfoSet& aSolnSet, World* aWorld,
                           Marketplace* aMarketplace, const int aPeriod );
+    
     void print( std::ostream& aOut ) const;
     void printCSV( std::ostream& aOut, int period, bool aPrintHeader ) const;
     

--- a/cvs/objects/util/base/include/supply_demand_curve_saver.h
+++ b/cvs/objects/util/base/include/supply_demand_curve_saver.h
@@ -41,7 +41,7 @@ public:
 					   const IClimateModel* aClimateModel,
 					   const int aPeriod );
 
-    virtual void printSD( ostream& aOut, Scenario* aScenario, const int aPeriod, bool printHeader );
+    virtual void printCSV( ostream& aOut, Scenario* aScenario, const int aPeriod, bool aPrintHeader );
 
     virtual int getMarketIndex(const string& aMarketName, vector<SolutionInfo> &aSolvable );
 

--- a/cvs/objects/util/base/include/supply_demand_curve_saver.h
+++ b/cvs/objects/util/base/include/supply_demand_curve_saver.h
@@ -1,0 +1,56 @@
+#include <cassert>
+#include <vector>
+#include <iostream>
+#include "containers/include/imodel_feedback_calc.h"
+#include "containers/include/scenario.h"
+#include "solution/util/include/solution_info.h"
+
+using namespace std;
+using namespace xercesc;
+
+/*!
+ * \ingroup Objects
+ * \brief Writes out supply & demand curves for user-designated markets
+ * \details 
+ *
+ * \author Rich Plevin
+ */
+class SupplyDemandCurveSaver : public IModelFeedbackCalc
+{
+public:
+    SupplyDemandCurveSaver();
+    virtual ~SupplyDemandCurveSaver();
+    
+    static const std::string& getXMLNameStatic();
+    
+    // INamed methods
+    virtual const std::string& getName() const;
+    
+    // IParsable methods
+    virtual bool XMLParse( const xercesc::DOMNode* aNode );
+    
+    // IRoundTrippable methods
+    virtual void toInputXML( std::ostream& aOut, Tabs* aTabs ) const;
+    
+    // IModelFeedbackCalc methods
+    virtual void calcFeedbacksBeforePeriod( Scenario* aScenario,
+					    const IClimateModel* aClimateModel,
+					    const int aPeriod );
+    
+    virtual void calcFeedbacksAfterPeriod( Scenario* aScenario,
+					   const IClimateModel* aClimateModel,
+					   const int aPeriod );
+
+    virtual void printSD( ostream& aOut, Scenario* aScenario, const int aPeriod, bool printHeader );
+
+    virtual int getMarketIndex(const string& aMarketName, vector<SolutionInfo> &aSolvable );
+
+protected:
+    //! The name of this feedback
+    std::string mName;
+    
+    //! The number of points to compute
+    int mNumPoints;
+
+    static std::ios_base::openmode mOpenMode;
+};

--- a/cvs/objects/util/base/include/supply_demand_curve_saver.h
+++ b/cvs/objects/util/base/include/supply_demand_curve_saver.h
@@ -21,25 +21,25 @@ public:
     SupplyDemandCurveSaver();
     virtual ~SupplyDemandCurveSaver();
     
-    static const std::string& getXMLNameStatic();
+    static const string& getXMLNameStatic();
     
     // INamed methods
-    virtual const std::string& getName() const;
+    virtual const string& getName() const;
     
     // IParsable methods
     virtual bool XMLParse( const xercesc::DOMNode* aNode );
     
     // IRoundTrippable methods
-    virtual void toInputXML( std::ostream& aOut, Tabs* aTabs ) const;
+    virtual void toInputXML( ostream& aOut, Tabs* aTabs ) const;
     
     // IModelFeedbackCalc methods
     virtual void calcFeedbacksBeforePeriod( Scenario* aScenario,
-					    const IClimateModel* aClimateModel,
-					    const int aPeriod );
+                                            const IClimateModel* aClimateModel,
+                                            const int aPeriod );
     
     virtual void calcFeedbacksAfterPeriod( Scenario* aScenario,
-					   const IClimateModel* aClimateModel,
-					   const int aPeriod );
+    					                   const IClimateModel* aClimateModel,
+                                           const int aPeriod );
 
     virtual void printCSV( ostream& aOut, Scenario* aScenario, const int aPeriod, bool aPrintHeader );
 
@@ -49,8 +49,9 @@ protected:
     //! The name of this feedback
     std::string mName;
     
-    //! The number of points to compute
-    int mNumPoints;
+    bool mIsPricesRelative;
+    
+    std::vector<double>mPrices;
 
     static std::ios_base::openmode mOpenMode;
 };

--- a/cvs/objects/util/base/source/Makefile
+++ b/cvs/objects/util/base/source/Makefile
@@ -14,6 +14,7 @@ OBJS       = atom.o \
              model_time.o \
              summary.o \
              supply_demand_curve.o \
+             supply_demand_curve_saver.o \
              timer.o \
              calibrate_share_weight_visitor.o \
              calibrate_resource_visitor.o \

--- a/cvs/objects/util/base/source/supply_demand_curve.cpp
+++ b/cvs/objects/util/base/source/supply_demand_curve.cpp
@@ -150,13 +150,13 @@ void SupplyDemandCurve::calculatePoints( const int aNumPoints, SolutionInfoSet& 
 *
 * This function prints the vector of SupplyDemandPoints created during the calculatePoints function.
 * It creates a copy of points and sorts them before printing them. This was done so that the printing function
-* could remain constant. The points are printed to the Logger passed as an argument.
+* could remain constant. The points are printed to the ostream passed as an argument.
 *
 * \param sdLog Logger to print the points to.
 */
-void SupplyDemandCurve::print( ILogger& aSDLog ) const {
-    aSDLog << "Supply and Demand curves for: " << mMarketName << endl;
-    aSDLog << "Price,Demand,Supply,Fx" << endl;
+void SupplyDemandCurve::print( std::ostream& aOut ) const {
+    aOut << "Supply and Demand curves for: " << mMarketName << endl;
+    aOut << "Price,Demand,Supply,Fx" << endl;
 
     // Create a copy of the points vector so that we can sort it while keeping the print function constant.
     // Since the vector contains pointers to SupplyDemandPoints, this is relatively inexpensive.
@@ -165,11 +165,31 @@ void SupplyDemandCurve::print( ILogger& aSDLog ) const {
     // Sort the SupplyDemandPoint object pointers in the pointsCopy vector by increasing price by using the LesserPrice binary operator. 
     sort( pointsCopy.begin(), pointsCopy.end(), SupplyDemandPoint::LesserPrice() );
     for ( vector<SupplyDemandPoint*>::const_iterator i = pointsCopy.begin(); i != pointsCopy.end(); i++ ) {
-        ( *i )->print( aSDLog );
+        ( *i )->print( aOut );
     }
 
-    aSDLog << endl;
+    aOut << endl;
 }
+
+// Same as above but with period and market added in csv format
+void SupplyDemandCurve::print2( std::ostream& aOut, int period, bool printHeader ) const {
+    if ( printHeader )
+        aOut << "Market,Period,Price,Demand,Supply,Fx" << endl;
+    
+    // Create a copy of the points vector so that we can sort it while keeping the print function constant.
+    // Since the vector contains pointers to SupplyDemandPoints, this is relatively inexpensive.
+    vector<SupplyDemandPoint*> pointsCopy( mPoints );
+    
+    // Sort the SupplyDemandPoint object pointers in the pointsCopy vector by increasing price by using the LesserPrice binary operator.
+    sort( pointsCopy.begin(), pointsCopy.end(), SupplyDemandPoint::LesserPrice() );
+    for ( vector<SupplyDemandPoint*>::const_iterator i = pointsCopy.begin(); i != pointsCopy.end(); i++ ) {
+        aOut << mMarketName << "," << period << ",";
+        ( *i )->print( aOut );
+    }
+    
+    //aOut << endl;
+}
+
 
 //! Constructor
 SupplyDemandCurve::SupplyDemandPoint::SupplyDemandPoint( const double aPrice, const double aDemand, const double aSupply, const double aFx )
@@ -191,9 +211,9 @@ double SupplyDemandCurve::SupplyDemandPoint::getPrice() const {
 *
 * Print the point in a csv format to the specified logger.
 *
-* \param sdLog The Logger to print to.
+* \param aOut The ostream to print to.
 */
-void SupplyDemandCurve::SupplyDemandPoint::print( ILogger& aSDLog ) const {
-    aSDLog << mPrice << "," << mDemand << "," << mSupply << "," << mFx << endl;
+void SupplyDemandCurve::SupplyDemandPoint::print( std::ostream& aOut ) const {
+    aOut << mPrice << "," << mDemand << "," << mSupply << "," << mFx << endl;
 }
 

--- a/cvs/objects/util/base/source/supply_demand_curve.cpp
+++ b/cvs/objects/util/base/source/supply_demand_curve.cpp
@@ -109,8 +109,6 @@ void SupplyDemandCurve::calculatePoints( const std::vector<double>& aPrices, Sol
     double scaledPrice = x[ mMarketNumber ];    // after scaling
     double scalingFactor = (aIsPricesRelative ? scaledPrice : scaledPrice / actualPrice);
 
-    cout << "Market " << mMarketNumber << ": Actual price: " << actualPrice << " Scaled price: " << scaledPrice << " Scaling factor: " << scalingFactor << endl;
-    
     // Call F( x ), store the result in fx
     F(x, fx);
     

--- a/cvs/objects/util/base/source/supply_demand_curve.cpp
+++ b/cvs/objects/util/base/source/supply_demand_curve.cpp
@@ -172,8 +172,8 @@ void SupplyDemandCurve::print( std::ostream& aOut ) const {
 }
 
 // Same as above but with period and market added in csv format
-void SupplyDemandCurve::print2( std::ostream& aOut, int period, bool printHeader ) const {
-    if ( printHeader )
+void SupplyDemandCurve::printCSV( std::ostream& aOut, int period, bool aPrintHeader ) const {
+    if ( aPrintHeader )
         aOut << "Market,Period,Price,Demand,Supply,Fx" << endl;
     
     // Create a copy of the points vector so that we can sort it while keeping the print function constant.

--- a/cvs/objects/util/base/source/supply_demand_curve_saver.cpp
+++ b/cvs/objects/util/base/source/supply_demand_curve_saver.cpp
@@ -1,0 +1,166 @@
+#include <cassert>
+#include <vector>
+#include <iostream>
+#include "containers/include/imodel_feedback_calc.h"
+#include "containers/include/scenario.h"
+#include "containers/include/world.h"
+#include "solution/util/include/solution_info_set.h"
+#include "solution/util/include/solution_info.h"
+#include "solution/util/include/solvable_solution_info_filter.h"
+#include "solution/util/include/solution_info_param_parser.h"
+#include "util/base/include/auto_file.h"
+#include "util/base/include/definitions.h"
+#include "util/base/include/supply_demand_curve.h"
+#include "util/base/include/supply_demand_curve_saver.h"
+#include "util/base/include/xml_helper.h"
+#include "util/base/include/model_time.h"
+#include "marketplace/include/market.h"
+#include "marketplace/include/marketplace.h"
+
+using namespace std;
+using namespace xercesc;
+
+
+#define DEFAULT_NUM_POINTS 10
+
+SupplyDemandCurveSaver::SupplyDemandCurveSaver() : mNumPoints( DEFAULT_NUM_POINTS )
+{
+  
+}
+
+// First open uses "out" mode to overwrite; subsequent calls append
+std::ios_base::openmode SupplyDemandCurveSaver::mOpenMode = std::ios_base::out;
+
+SupplyDemandCurveSaver::~SupplyDemandCurveSaver() {
+}
+
+const string& SupplyDemandCurveSaver::getXMLNameStatic() {
+  // This is the string you will use to refer to this object
+  // in input files.
+  const static string XML_NAME = "supply-demand-curve";
+  return XML_NAME;
+}
+
+const string& SupplyDemandCurveSaver::getName() const {
+    return mName;
+}
+
+/* Example XML:
+<scenario>
+   <supply-demand-curve-saver name="USAbiomass">
+      <num-points>10</num-points>
+   </supply-demand-curve-saver>
+</scenario>
+ */
+
+bool SupplyDemandCurveSaver::XMLParse( const DOMNode* aNode ) {
+    /*! \pre Make sure we were passed a valid node. */
+    assert( aNode );
+    
+    // get the name attribute.
+    mName = XMLHelper<string>::getAttr( aNode, XMLHelper<void>::name() );
+
+    // get all child nodes.
+    DOMNodeList* nodeList = aNode->getChildNodes();
+    
+    // loop through the child nodes.
+    for ( unsigned int i = 0; i < nodeList->getLength(); i++ ){
+        DOMNode* curr = nodeList->item( i );
+        string nodeName = XMLHelper<string>::safeTranscode( curr->getNodeName() );
+        
+        if ( nodeName == XMLHelper<void>::text() ) {
+            continue;
+        }
+        else if ( nodeName == "num-points" ) {
+            mNumPoints = XMLHelper<int>::getValue( curr );
+        }
+        else {
+            ILogger& mainLog = ILogger::getLogger( "main_log" );
+            mainLog.setLevel( ILogger::ERROR );
+            mainLog << "Unknown element " << nodeName << " encountered while parsing " << getXMLNameStatic() << endl;
+        }
+    }
+    
+    return true;
+}
+
+void SupplyDemandCurveSaver::toInputXML( ostream& aOut, Tabs* aTabs ) const {
+    // XMLWriteOpeningTag( getXMLNameStatic(), aOut, aTabs );
+
+    aOut << "<" << getXMLNameStatic() << " name=\"" << mName << "\">" << endl;
+
+    XMLWriteElement( mNumPoints, "num-points", aOut, aTabs );
+    
+    XMLWriteClosingTag( getXMLNameStatic(), aOut, aTabs );
+}
+
+
+/*! \brief Find and print supply-demand curves for designated market.
+*
+* This function creates a SupplyDemandCurve for the designated market by calculating
+* the supply and demand at a series of prices, and to print the resulting curve.
+*
+* \author Rich Plevin (based on SolutionInfoSet::findAndPrintSD)
+* \param aWorld The world to use to calculate new points.
+* \param aMarketplace The marketplace to use to calculate new points.
+* \param aPeriod Period for which to print supply-demand curves.
+* \param aOut Output stream to print the curves to.
+*/
+void SupplyDemandCurveSaver::printSD( ostream& aOut, Scenario* aScenario, const int aPeriod, bool printHeader ) {
+  World* world = aScenario->getWorld();
+  Marketplace* marketplace = scenario->getMarketplace();
+  SolutionInfoSet solnInfoSet = SolutionInfoSet( marketplace );
+  SolutionInfoParamParser solnParams;
+  solnInfoSet.init( aPeriod, 0.001, 0.001, &solnParams );
+  vector<SolutionInfo> solvable = solnInfoSet.getSolvableSet();
+  
+  if ( solvable.size() == 0 )	// occurs in year 1975
+    return;
+
+  int market_index = getMarketIndex(mName, solvable);
+
+  if ( market_index < 0 ) {
+    aOut << "# Market for " << mName << " was not found." << endl;
+    
+  } else {
+    SupplyDemandCurve sdCurve( market_index, mName );
+    
+    sdCurve.calculatePoints( mNumPoints, solnInfoSet, world, marketplace, aPeriod );
+    sdCurve.print2( aOut, aPeriod, printHeader );
+  }
+}
+
+/*! \brief Find the given marketName in the given vector of solvable markets and return it's index, or -1 if not found.
+ */
+int SupplyDemandCurveSaver::getMarketIndex(const string& marketName, vector<SolutionInfo> &aSolvable ) {
+  for ( int i = 0; i < aSolvable.size(); ++i ) {
+    if ( aSolvable[ i ].getName() == marketName )
+      return i;
+  }
+  return -1;
+}
+
+void SupplyDemandCurveSaver::calcFeedbacksBeforePeriod( Scenario* aScenario,
+							const IClimateModel* aClimateModel,
+							const int aPeriod ) 
+{
+    // do nothing
+}
+
+void SupplyDemandCurveSaver::calcFeedbacksAfterPeriod( Scenario* aScenario,
+						       const IClimateModel* aClimateModel,
+						       const int aPeriod )
+{
+  if ( aPeriod == 0 )	// Nothing to do for initial period
+    return;
+  
+  const Configuration* conf = Configuration::getInstance();
+  std::string fileName = conf->getFile( "supplyDemandCurves", "supplyDemandCurves.csv");
+  
+  AutoOutputFile outFile(fileName, mOpenMode );
+    
+  // First time through (before resetting open mode to append) write header, too.
+  printSD( *outFile, scenario, aPeriod, mOpenMode == std::ios_base::out);
+
+  mOpenMode = std::ios_base::app;   // after first call, append
+}

--- a/cvs/objects/util/base/source/supply_demand_curve_saver.cpp
+++ b/cvs/objects/util/base/source/supply_demand_curve_saver.cpp
@@ -17,9 +17,7 @@
 #include "marketplace/include/market.h"
 #include "marketplace/include/marketplace.h"
 
-using namespace std;
 using namespace xercesc;
-
 
 #define DEFAULT_NUM_POINTS 10
 
@@ -98,15 +96,15 @@ void SupplyDemandCurveSaver::toInputXML( ostream& aOut, Tabs* aTabs ) const {
 /*! \brief Find and print supply-demand curves for designated market.
 *
 * This function creates a SupplyDemandCurve for the designated market by calculating
-* the supply and demand at a series of prices, and to print the resulting curve.
+* the supply and demand at a series of prices, and prints the resulting curve.
 *
 * \author Rich Plevin (based on SolutionInfoSet::findAndPrintSD)
-* \param aWorld The world to use to calculate new points.
-* \param aMarketplace The marketplace to use to calculate new points.
-* \param aPeriod Period for which to print supply-demand curves.
 * \param aOut Output stream to print the curves to.
+* \param aScenario the scenario to use to find the marketplace
+* \param aPeriod Period for which to print supply-demand curves.
+* \param aPrintHeader whether to print the CSV header (column names)
 */
-void SupplyDemandCurveSaver::printSD( ostream& aOut, Scenario* aScenario, const int aPeriod, bool printHeader ) {
+void SupplyDemandCurveSaver::printCSV( ostream& aOut, Scenario* aScenario, const int aPeriod, bool aPrintHeader ) {
   World* world = aScenario->getWorld();
   Marketplace* marketplace = scenario->getMarketplace();
   SolutionInfoSet solnInfoSet = SolutionInfoSet( marketplace );
@@ -126,7 +124,7 @@ void SupplyDemandCurveSaver::printSD( ostream& aOut, Scenario* aScenario, const 
     SupplyDemandCurve sdCurve( market_index, mName );
     
     sdCurve.calculatePoints( mNumPoints, solnInfoSet, world, marketplace, aPeriod );
-    sdCurve.print2( aOut, aPeriod, printHeader );
+    sdCurve.printCSV( aOut, aPeriod, aPrintHeader );
   }
 }
 
@@ -160,7 +158,7 @@ void SupplyDemandCurveSaver::calcFeedbacksAfterPeriod( Scenario* aScenario,
   AutoOutputFile outFile(fileName, mOpenMode );
     
   // First time through (before resetting open mode to append) write header, too.
-  printSD( *outFile, scenario, aPeriod, mOpenMode == std::ios_base::out);
+  printCSV( *outFile, scenario, aPeriod, mOpenMode == std::ios_base::out);
 
   mOpenMode = std::ios_base::app;   // after first call, append
 }

--- a/exe/sdcurves.xml
+++ b/exe/sdcurves.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scenario>
+	<supply-demand-curve name="globalcrude oil">
+		<price>0.500</price>
+		<price>0.750</price>
+		<price>0.999</price>
+		<price>1.000</price>
+		<price>1.001</price>
+		<price>1.250</price>
+		<price>1.500</price>
+	</supply-demand-curve>
+	<supply-demand-curve name="globalnatural gas">
+		<price>0.500</price>
+		<price>0.750</price>
+		<price>0.999</price>
+		<price>1.000</price>
+		<price>1.001</price>
+		<price>1.250</price>
+		<price>1.500</price>
+	</supply-demand-curve>
+	<supply-demand-curve name="USAbiomass">
+		<price>0.500</price>
+		<price>0.750</price>
+		<price>0.999</price>
+		<price>1.000</price>
+		<price>1.001</price>
+		<price>1.250</price>
+		<price>1.500</price>
+	</supply-demand-curve>	
+</scenario>


### PR DESCRIPTION
Various changes to support writing out supply and demand curves for designated markets:

- Created class SupplyDemandCurveSaver and added to parsing in scenario.cpp
- Modified SupplyDemandCurve to print to ostream rather than logger
- Created SupplyDemandCurve::print2 function to create a proper CSV format file
- Modified AutoOutputFile to support option file opening mode (now allowing append mode)