### PR TITLE
Fix null pointer reference in solar_technology.cpp

### DIFF
--- a/cvs/objects/technologies/source/solar_technology.cpp
+++ b/cvs/objects/technologies/source/solar_technology.cpp
@@ -379,7 +379,7 @@ void SolarTechnology::initCalc(
    }
 
    // Get number of no sun days
-   if ( pInfo || !pInfo->hasValue( "no-sun-days" ) )
+   if ( !pInfo || !pInfo->hasValue( "no-sun-days" ) )
    // Invalid input parameter
    {
       mNoSunDays = pInfo->getDouble( "no-sun-days", false );


### PR DESCRIPTION
Some code in `solar_technology.cpp` tries to guard against pInfo being NULL, but gets it wrong. The usual idiom is `if (p && p->foo`, but to keep this change consistent with other examples in this file, I've used `if (!p || p->foo)`.

```
solar_technology.cpp:382:34: warning: ‘this’ pointer is null [-Wnonnull]
  382 |    if ( pInfo || !pInfo->hasValue( "no-sun-days" ) )
      |                   ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```